### PR TITLE
move include/private/* to a standalone library, libparalloid

### DIFF
--- a/native/jni/Android.mk
+++ b/native/jni/Android.mk
@@ -25,11 +25,22 @@ LOCAL_SRC_FILES := \
 include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
-LOCAL_MODULE := paralloid_ui
-LOCAL_STATIC_LIBRARIES := minui liblog
+LOCAL_MODULE := libparalloid
 
 LOCAL_C_INCLUDES := \
-    $(LOCAL_PATH)/include \
+    $(LOCAL_PATH)/libparalloid/include \
+    
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
+
+LOCAL_SRC_FILES := \
+    libparalloid/images.cpp \
+    libparalloid/utils.cpp \
+    
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := paralloid_ui
+LOCAL_STATIC_LIBRARIES := minui liblog libparalloid
 
 LOCAL_SRC_FILES := \
     paralloid_ui/main.cpp \
@@ -42,10 +53,7 @@ include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := minfastbootd
-LOCAL_STATIC_LIBRARIES := libbase libsparse
-
-LOCAL_C_INCLUDES := \
-    $(LOCAL_PATH)/include \
+LOCAL_STATIC_LIBRARIES := libbase libsparse libparalloid
 
 LOCAL_SRC_FILES := \
     minfastbootd/main.cpp \

--- a/native/jni/libparalloid/images.cpp
+++ b/native/jni/libparalloid/images.cpp
@@ -1,0 +1,60 @@
+#include <paralloid/images.h>
+
+using namespace std;
+
+vector<BootableImage> BootableImage::scanImages(fs::path base_path) {
+    auto images = vector<BootableImage>();
+    // An "image" is defined as a directory under base_path that contains
+    // at least system.img (there could be extra images such as product.img)
+    for (auto& p: fs::directory_iterator(base_path)) {
+        if (!p.is_directory()) continue;
+        if (!fs::exists(p / fs::path("system.img"))) continue;
+        auto relative_path = fs::relative(p, base_path);
+        images.push_back(BootableImage(base_path, relative_path.string()));
+    }
+    return images;
+}
+
+bool FlashableTargetDesc::storageDeviceMounted() {
+    if (storage_device == "sdcard" && !fs::exists("/dev/.sdcard_mounted")) {
+        return false;
+    }
+        
+    if (storage_device == "userdata" && !fs::exists("/dev/.userdata_mounted")) {
+        return false;
+    }
+        
+    return true;
+}
+
+BootableImage FlashableTargetDesc::toBootableImage() {
+    auto base_path = fs::path(storage_device == "sdcard" ?
+        EXT_SDCARD_BASE_PATH : USERDATA_BASE_PATH);
+    return BootableImage(base_path, image_name);
+}
+
+std::optional<FlashableTargetDesc> FlashableTargetDesc::parse(std::string desc) {
+    FlashableTargetDesc ret;
+        
+    auto splitted = split(desc, '_');
+
+    if (splitted.size() < 2 || splitted.size() > 3) {
+        return std::nullopt;
+    }
+
+    ret.storage_device = splitted[0];
+    if (ret.storage_device != "sdcard" && ret.storage_device != "userdata") {
+        return std::nullopt;
+    }
+
+    ret.image_name = splitted[1];
+    
+    if (splitted.size() == 3) {
+        ret.partition_name = splitted[2];
+        if (ret.partition_name != "system" && ret.partition_name != "product") {
+            return std::nullopt;
+        }
+    }
+        
+    return ret;
+}

--- a/native/jni/libparalloid/include/paralloid/utils.h
+++ b/native/jni/libparalloid/include/paralloid/utils.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+#include <vector>
+
+std::vector<std::string> split(const std::string &s, char delim);
+
+void rebootInto(const char* target);

--- a/native/jni/libparalloid/utils.cpp
+++ b/native/jni/libparalloid/utils.cpp
@@ -1,14 +1,13 @@
-#pragma once
+#include <paralloid/utils.h>
+
 #include <iostream>
-#include <string>
 #include <sstream>
-#include <vector>
 
 #include <sys/syscall.h>
 #include <sys/reboot.h>
 #include <unistd.h>
 
-static std::vector<std::string> split(const std::string &s, char delim) {
+std::vector<std::string> split(const std::string &s, char delim) {
     std::vector<std::string> result;
     std::stringstream ss(s);
     std::string item;
@@ -20,7 +19,7 @@ static std::vector<std::string> split(const std::string &s, char delim) {
     return result;
 } 
 
-static void rebootInto(const char* target) {
+void rebootInto(const char* target) {
     sync();
     
     if (target == nullptr) {

--- a/native/jni/minfastbootd/commands.cpp
+++ b/native/jni/minfastbootd/commands.cpp
@@ -23,8 +23,8 @@
 #include <android-base/parseint.h>
 #include <android-base/stringprintf.h>
 
-#include <private/images.h>
-#include <private/utils.h>
+#include <paralloid/images.h>
+#include <paralloid/utils.h>
 
 void ListImages(FastbootDevice *device, std::string base_path) {
     auto images = BootableImage::scanImages(base_path);

--- a/native/jni/minfastbootd/flashing.cpp
+++ b/native/jni/minfastbootd/flashing.cpp
@@ -5,9 +5,10 @@
 #include <sparse/sparse.h>
 
 #include <cstdlib>
+#include <iostream>
 #include <vector>
 
-#include <private/images.h>
+#include <paralloid/images.h>
 
 constexpr uint32_t SPARSE_HEADER_MAGIC = 0xed26ff3a;
 

--- a/native/jni/paralloid_ui/menu.cpp
+++ b/native/jni/paralloid_ui/menu.cpp
@@ -2,7 +2,7 @@
 #include "main.h"
 #include <sstream>
 
-#include <private/utils.h>
+#include <paralloid/utils.h>
 #include <sys/reboot.h>
 
 #define DEFAULT_HELP_TEXT \

--- a/native/jni/paralloid_ui/menu.h
+++ b/native/jni/paralloid_ui/menu.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "ui.h"
-#include <private/images.h>
+#include <paralloid/images.h>
 
 #include <chrono>
 #include <filesystem>


### PR DESCRIPTION
Don't pollute every single cpp file in our repository with includes from
utility functions. In addition, move some long and ugly utility
functions out of the shared headers.