### PR TITLE
Add firmware loading

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -63,6 +63,9 @@ cp files/init rootfs/system/bin/init
 chmod 0755 rootfs/init
 chmod 0755 rootfs/system/bin/init
 
+cp files/hotplug rootfs/bin/hotplug
+chmod 0755 rootfs/bin/hotplug
+
 cp files/format-userdata-image rootfs/bin/format-userdata-image
 chmod 0755 rootfs/bin/format-userdata-image
 

--- a/files/hotplug
+++ b/files/hotplug
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ "$SUBSYSTEM" = firmware ];then
+    found=false
+    for p in /target_tmp/vendor /vendor /target/vendor;do
+        if [ -f $p/firmware/$FIRMWARE ];then
+            echo 1 > /sys/class/firmware/$FIRMWARE/loading
+            cat $p/firmware/$FIRMWARE > /sys/class/firmware/$FIRMWARE/data
+            echo 0 > /sys/class/firmware/$FIRMWARE/loading
+            found=true
+        fi
+    done
+    if ! $found;then
+            echo 0 > /sys/class/firmware/$FIRMWARE/loading
+    fi
+fi

--- a/files/init
+++ b/files/init
@@ -30,6 +30,8 @@ mount -t tmpfs none /dev
 mount -t tmpfs none /tmp
 mount -t pstore none /sys/fs/pstore
 
+echo /bin/hotplug > /proc/sys/kernel/hotplug
+
 mdev -s
 mdev -d
 


### PR DESCRIPTION
This is needed on Teracube 2e, otherwise DRM doesn't load
(or rather takes 60 seconds to timeout)

I haven't tested yet that this doesn't brick android boot