### PR TITLE
refactor out repetitive mount -o move calls and put Paralloid rootfs on ramdisk

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -30,7 +30,7 @@ popd
 rm -Rf rootfs rootfs.img
 
 # This list should include all possible first-stage mountpoints on all known devices
-mkdir -p rootfs/{apex,sbin,bin,config,proc,sys,dev,system/bin,vendor,product,odm,mnt,first_stage_ramdisk,tmp,metadata,bt_firmware,efs,firmware,oem,persist,postinstall,system_ext,sec_storage,dev/pts,dev/socket,sys/fs/selinux,mnt/vendor,mnt/product,debug_ramdisk,system/system_ext/etc/init/config,system/etc/init/config/,prism,optics}
+mkdir -p rootfs/{apex,sbin,bin,config,proc,sys,dev,system/bin,vendor,product,odm,mnt,first_stage_ramdisk,tmp,metadata,bt_firmware,efs,firmware,oem,persist,postinstall,system_ext,sec_storage,dev/pts,dev/socket,sys/fs/selinux,mnt/vendor,mnt/product,debug_ramdisk,system/system_ext/etc/init/config,system/etc/init/config/,prism,optics,paralloid_ramdisk,paralloid_oldroot}
 # Temporary directories for Paralloid's boot process
 mkdir -p rootfs/target/ rootfs/target_tmp/
 
@@ -66,7 +66,9 @@ chmod 0755 rootfs/init
 chmod 0755 rootfs/system/bin/init
 
 cp files/format-userdata-image rootfs/bin/format-userdata-image
+cp files/recursive_umount rootfs/bin/recursive_umount
 chmod 0755 rootfs/bin/format-userdata-image
+chmod 0755 rootfs/bin/recursive_umount
 
 cp native/libs/armeabi-v7a/e2fsdroid rootfs/bin/e2fsdroid
 chmod 0755 rootfs/bin/e2fsdroid

--- a/create.sh
+++ b/create.sh
@@ -29,8 +29,10 @@ popd
 
 rm -Rf rootfs rootfs.img
 
+# This list should include all possible first-stage mountpoints on all known devices
 mkdir -p rootfs/{apex,sbin,bin,config,proc,sys,dev,system/bin,vendor,product,odm,mnt,first_stage_ramdisk,tmp,metadata,bt_firmware,efs,firmware,oem,persist,postinstall,system_ext,sec_storage,dev/pts,dev/socket,sys/fs/selinux,mnt/vendor,mnt/product,debug_ramdisk,system/system_ext/etc/init/config,system/etc/init/config/,prism,optics}
-mkdir -p rootfs/target/ rootfs/target_tmp/{dev,proc,sys,mnt,debug_ramdisk,metadata,vendor,odm,prism,optics,apex}
+# Temporary directories for Paralloid's boot process
+mkdir -p rootfs/target/ rootfs/target_tmp/
 
 cp busybox/build/busybox rootfs/bin/busybox
 chmod 0755 rootfs/bin/busybox

--- a/create.sh
+++ b/create.sh
@@ -73,8 +73,10 @@ chmod 0755 rootfs/bin/mke2fs
 
 cp native/libs/armeabi-v7a/paralloid_ui rootfs/bin/paralloid_ui
 cp native/libs/armeabi-v7a/minfastbootd rootfs/bin/minfastbootd
+cp native/libs/armeabi-v7a/move_mount_tree rootfs/bin/move_mount_tree
 chmod 0755 rootfs/bin/paralloid_ui
 chmod 0755 rootfs/bin/minfastbootd
+chmod 0755 rootfs/bin/move_mount_tree
 
 mkdir -p rootfs/res/images
 cp files/fonts/12x22.png rootfs/res/images/font.png

--- a/files/init
+++ b/files/init
@@ -4,6 +4,25 @@ set -x
 
 export PATH=/bin:/sbin
 
+# Move our rootfs to a ramdisk to free up the original system partition
+if [ -z "$PARALLOID_RAMDISK" ];then
+    # Gain access to the raw rootfs without all the mountpoints
+    mount -o bind / /paralloid_oldroot
+    # Copy all of rootfs to a tmpfs mounted on /paralloid_ramdisk
+    mount -t tmpfs none /paralloid_ramdisk
+    cp -R /paralloid_oldroot/* /paralloid_ramdisk/
+    umount /paralloid_oldroot/
+    # Switch to the new rootfs in ramdisk
+    MOVE_MOUNT_RBIND_DIRS="sys" move_mount_tree / /paralloid_ramdisk
+    export PARALLOID_RAMDISK=true
+    cd /paralloid_ramdisk
+    pivot_root /paralloid_ramdisk paralloid_oldroot
+    exec chroot . /system/bin/init
+fi
+
+# Unmount the old root filesystem to free up the system partition
+recursive_umount /paralloid_oldroot
+
 # Mount a tmpfs on /target_tmp so that we can create mountpoints as needed
 mount -t tmpfs none /target_tmp
 

--- a/files/init
+++ b/files/init
@@ -4,6 +4,9 @@ set -x
 
 export PATH=/bin:/sbin
 
+# Mount a tmpfs on /target_tmp so that we can create mountpoints as needed
+mount -t tmpfs none /target_tmp
+
 # Note: we cannot move /sys to /target_tmp/sys, because
 # bionic libc wants at least one of /dev/null and /sys/fs/selinux/null
 # otherwise it segfaults. Moving /sys here will cause all the following

--- a/files/init
+++ b/files/init
@@ -221,9 +221,37 @@ TARGET_DIR=$(dirname $TARGET)
 
 if [ $TARGET == "internal" ];then
     mount -o ro /dev/block/mapper/system_orig /target
-    # Note: the other system mountpoints, if present as first stage mounts, will be
-    # moved back by the next move_mount_tree command. There is no need to do anything
-    # here specifically for them.
+    
+    # We skipped these partitions using skip_mount.cfg in our rootfs because
+    # they might have been deleted by the user to free up space (if they
+    # do not want to use official ROMs in the internal partitions)
+    # Not skipping them in first stage ramdisk would result in crashes if they
+    # are missing.
+    # Try to mount them back here, and later we shall remove the unneeded
+    # according to the skip_mount.cfg from the actual system
+    # Note that these partitions are mounted in /target_tmp -- they will be
+    # moved to /target by the next move_mount_tree command
+    mkdir -p /target_tmp/{system_ext,product,oem}
+    mount -o ro /dev/block/mapper/system_ext /target_tmp/system_ext
+    mount -o ro /dev/block/mapper/product /target_tmp/product
+    mount -o ro /dev/block/mapper/oem /target_tmp/oem
+    # TODO: implement slotselect for {,Virtual-}A/B
+    
+    # Remove first-stage mountpoints according to skip_mount.cfg
+    for part in /target/system /target/system/system_ext /target/system_ext;do
+        cfg=$part/etc/init/config/skip_mount.cfg
+        if [ ! -f $cfg ];then
+            continue
+        fi
+        
+        for mnt in $(cat $cfg);do
+            if [ -z "${mnt// }" ];then
+                continue
+            fi
+            # The first-stage mountpoints were moved to /target_tmp
+            umount /target_tmp$mnt
+        done
+    done
 else
     # Create userdata image if it doesn't exist yet
     if [ ! -f "$TARGET_DIR/userdata.img" ];then
@@ -240,12 +268,6 @@ else
         # Call the same script in /bin that the diverter UI uses
         format-userdata-image $TARGET_DIR/userdata.img
     fi
-    
-    # Remove the default system partition mountpoints -- if these are needed, they
-    # shall be flashed as images in their respective directory
-    umount /target_tmp/oem
-    umount /target_tmp/system_ext
-    umount /target_tmp/product
     
     # Mount the system images
     mount -o ro,loop $TARGET /target

--- a/files/init
+++ b/files/init
@@ -4,23 +4,12 @@ set -x
 
 export PATH=/bin:/sbin
 
-mount -o move /dev /target_tmp/dev
-mount -o move /proc /target_tmp/proc
 # Note: we cannot move /sys to /target_tmp/sys, because
 # bionic libc wants at least one of /dev/null and /sys/fs/selinux/null
 # otherwise it segfaults. Moving /sys here will cause all the following
 # commands to break. Using recursive bind mount copies the mount tree,
 # preserving the original one, which should make it safe.
-mount --rbind /sys /target_tmp/sys
-mount -o move /mnt /target_tmp/mnt
-mount -o move /debug_ramdisk /target_tmp/debug_ramdisk
-mount -o move /metadata /target_tmp/metadata
-mount -o move /vendor /target_tmp/vendor
-mount -o move /odm /target_tmp/odm
-mount -o move /apex /target_tmp/apex
-mount -o move /prism /target_tmp/prism
-mount -o move /optics /target_tmp/optics
-#TODO: Other mount points for non-GSI (system_ext? product?) + Device-specific (prism,optics)
+MOVE_MOUNT_RBIND_DIRS="sys" move_mount_tree / /target_tmp
 
 # Re-mount some of the filesystems we just moved
 # We don't need to mount /sys because we used --rbind
@@ -229,6 +218,9 @@ TARGET_DIR=$(dirname $TARGET)
 
 if [ $TARGET == "internal" ];then
     mount -o ro /dev/block/mapper/system_orig /target
+    # Note: the other system mountpoints, if present as first stage mounts, will be
+    # moved back by the next move_mount_tree command. There is no need to do anything
+    # here specifically for them.
 else
     # Create userdata image if it doesn't exist yet
     if [ ! -f "$TARGET_DIR/userdata.img" ];then
@@ -245,6 +237,11 @@ else
         # Call the same script in /bin that the diverter UI uses
         format-userdata-image $TARGET_DIR/userdata.img
     fi
+    
+    # Remove the default system partition mountpoints -- if these are needed, they
+    # shall be flashed as images in their respective directory
+    umount /target_tmp/system_ext
+    umount /target_tmp/product
     
     # Mount the system images
     mount -o ro,loop $TARGET /target
@@ -264,20 +261,9 @@ else
     mount -o bind /dev/null /adb_debug.prop
 fi
 
-# Undo what we did earlier
-mount -o move /target_tmp/apex /target/apex
-mount -o move /target_tmp/dev /target/dev
-mount -o move /target_tmp/proc /target/proc
-mount -o move /target_tmp/sys /target/sys
-mount -o move /target_tmp/mnt /target/mnt
-mount -o move /target_tmp/debug_ramdisk /target/debug_ramdisk
-mount -o move /target_tmp/metadata /target/metadata
-mount -o move /target_tmp/vendor /target/vendor
-mount -o move /target_tmp/odm /target/odm
-mount -o move /target_tmp/apex /target/apex
-mount -o move /target_tmp/prism /target/prism
-mount -o move /target_tmp/optics /target/optics
-#TODO: Other mount points for non-GSI (system_ext? product?)
+# Move all first stage mountpoints to the new root (excluding those that
+# we explicitly unmounted)
+move_mount_tree /target_tmp /target
 
 if [ $TARGET != "internal" ];then
     # Create loop device for userdata on sdcard

--- a/files/init
+++ b/files/init
@@ -243,6 +243,7 @@ else
     
     # Remove the default system partition mountpoints -- if these are needed, they
     # shall be flashed as images in their respective directory
+    umount /target_tmp/oem
     umount /target_tmp/system_ext
     umount /target_tmp/product
     

--- a/files/recursive_umount
+++ b/files/recursive_umount
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+ROOT="$1"
+
+if [ -z "$ROOT" ];then
+    exit 1
+fi
+
+for mnt in $(cat /proc/mounts | grep " $ROOT" | cut -d " " -f 2 | sort -r);do
+    umount "$mnt"
+done

--- a/native/jni/Android.mk
+++ b/native/jni/Android.mk
@@ -67,4 +67,13 @@ LOCAL_LDLIBS += -lz
 
 include $(BUILD_EXECUTABLE)
 
+include $(CLEAR_VARS)
+LOCAL_MODULE := move_mount_tree
+LOCAL_STATIC_LIBRARIES := libbase libparalloid
+
+LOCAL_SRC_FILES := \
+    move_mount_tree/main.cpp \
+    
+include $(BUILD_EXECUTABLE)
+
 include $(LOCAL_PATH)/external/Android.mk

--- a/native/jni/move_mount_tree/main.cpp
+++ b/native/jni/move_mount_tree/main.cpp
@@ -1,0 +1,101 @@
+#include <fcntl.h>
+#include <mntent.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <android-base/strings.h>
+#include <paralloid/utils.h>
+
+#include <filesystem>
+#include <iostream>
+
+using android::base::StartsWith;
+using namespace std::literals;
+namespace fs = std::filesystem;
+
+// Adapted from platform/system/core/init/switch_root.cpp
+std::vector<std::string> GetMountsToMove(const std::string& old_root, const std::string& new_root) {
+    auto fp = std::unique_ptr<std::FILE, decltype(&endmntent)>{setmntent("/proc/mounts", "re"),
+                                                               endmntent};
+    if (fp == nullptr) {
+        std::cout << "Failed to open /proc/mounts" << std::endl;
+    }
+    
+    std::vector<std::string> result;
+    mntent* mentry;
+    while ((mentry = getmntent(fp.get())) != nullptr) {
+        // We won't try to move old root.
+        if (fs::path(mentry->mnt_dir) == fs::path(old_root)) {
+            continue;
+        }
+        
+        // Ignore everything outside old_root
+        if (old_root != "/" && !StartsWith(mentry->mnt_dir, old_root + "/")) {
+            continue;
+        }
+        
+        // The new root mount is handled separately.
+        if (mentry->mnt_dir == new_root) {
+            continue;
+        }
+        
+        // Move operates on subtrees, so do not try to move children of other mounts.
+        if (std::find_if(result.begin(), result.end(), [&mentry](const auto& older_mount) {
+                return StartsWith(mentry->mnt_dir, older_mount + "/");
+            }) != result.end()) {
+            continue;
+        }
+        
+        result.emplace_back(mentry->mnt_dir);
+    }
+    
+    return result;
+}
+
+void NormalizePathString(std::string& p) {
+    if (p != "/" && p.at(p.length() - 1) == '/') {
+        p.replace(p.length() - 1, 1, "");
+    }
+}
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        std::cout << "Usage: move_mount_tree <old_root> <new_root>" << std::endl;
+        return -1;
+    }
+    
+    std::vector<std::string> rbind_dirs;
+    if (auto _rbind_dirs = std::getenv("MOVE_MOUNT_RBIND_DIRS")) {
+        std::string _rbind_dirs_str(_rbind_dirs);
+        rbind_dirs = split(_rbind_dirs_str, ';');
+    }
+    
+    std::string old_root(argv[1]);
+    std::string new_root(argv[2]);
+    NormalizePathString(old_root);
+    NormalizePathString(new_root);
+    std::cout << "Moving mount tree from " << old_root << " to " << new_root << std::endl;
+    
+    auto mounts = GetMountsToMove(old_root, new_root);
+    for (auto& mnt : mounts) {
+        auto new_mount_path = old_root != "/" ?
+            std::string(mnt).replace(0, old_root.length(), new_root) : (new_root + mnt);
+        std::cout << "Moving " << mnt << " to " << new_mount_path << std::endl;
+        bool should_rbind = false;
+        for (auto& d : rbind_dirs) {
+            if (fs::path(mnt) == fs::path(old_root) / d) {
+                should_rbind = true;
+                break;
+            }
+        }
+        
+        mkdir(new_mount_path.c_str(), 0755);
+        if (should_rbind) {
+            std::cout << "Using rbind instead of move for " << mnt << std::endl;
+            mount(mnt.c_str(), new_mount_path.c_str(), nullptr, MS_BIND | MS_REC, nullptr);
+        } else {
+            mount(mnt.c_str(), new_mount_path.c_str(), nullptr, MS_MOVE, nullptr);
+        }
+    }
+}


### PR DESCRIPTION
This PR does a few things:

1. Added a small utility `move_mount_tree` to move an entire mount tree at once, with the ability to exclude some mountpoints and use `rbind` for them. This saves us the trouble of explicitly listing all possible mountpoints every time we want to `pivot_root` (...so that repetitive code for pivoting our rootfs to ramdisk can be eliminated later)
2. Since our init script doesn't care about the specific mountpoints anymore, I added support for parsing `skip_mount.cfg` to unmount unneeded partitions when booting the internal target. This addresses one of our TODOs.
3.  Finally, the main objective of this PR: pivot our rootfs to a ramdisk (tmpfs) on boot, and free up the original block device. This will facilitate our implementation of #2, which requires writing to the block device used by Paralloid. (we could use the logical partitions trick, but that won't work on non-dynamic SaR, and I don't really want to pull in lp dependencies right now).